### PR TITLE
Resolve NaN error on revision numbers longer than 5 digits

### DIFF
--- a/subversion.js
+++ b/subversion.js
@@ -45,9 +45,8 @@ const subversion = {
         const lines = data.split(/\n/);
 
         lines.forEach((line, index) => {
-            if (line.substring(5, 6) === '-') return;
             const revision = line.split(' ').filter(s => s)[0];
-            if (revision) this.revisions[index] = parseInt(revision);
+            if (revision && revision != '-') this.revisions[index] = parseInt(revision);
         });
 
         return this.revisions;


### PR DESCRIPTION
Resolves error Revision is NaN error stopping blame at first local edit to a file. The 'no revision' dash was being searched for by character offset in the blame line, but this was not catching the '-' for revision lengths longer than 5 characters. 